### PR TITLE
Remove vscode conversion

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -330,8 +330,8 @@ spec:
                           - id
                           type: object
                         vscodeLaunch:
-                          description: Command providing the definition of a VsCode
-                            launch action
+                          description: "Command providing the definition of a VsCode
+                            launch action \n Deprecated; removed in v1alpha2"
                           oneOf:
                           - required:
                             - uri
@@ -385,8 +385,8 @@ spec:
                           - id
                           type: object
                         vscodeTask:
-                          description: Command providing the definition of a VsCode
-                            Task
+                          description: "Command providing the definition of a VsCode
+                            Task \n Deprecated; removed in v1alpha2"
                           oneOf:
                           - required:
                             - uri
@@ -1137,8 +1137,9 @@ spec:
                                     - id
                                     type: object
                                   vscodeLaunch:
-                                    description: Command providing the definition
-                                      of a VsCode launch action
+                                    description: "Command providing the definition
+                                      of a VsCode launch action \n Deprecated; removed
+                                      in v1alpha2"
                                     oneOf:
                                     - required:
                                       - uri
@@ -1196,8 +1197,8 @@ spec:
                                     - id
                                     type: object
                                   vscodeTask:
-                                    description: Command providing the definition
-                                      of a VsCode Task
+                                    description: "Command providing the definition
+                                      of a VsCode Task \n Deprecated; removed in v1alpha2"
                                     oneOf:
                                     - required:
                                       - uri
@@ -2055,8 +2056,8 @@ spec:
                               - id
                               type: object
                             vscodeLaunch:
-                              description: Command providing the definition of a VsCode
-                                launch action
+                              description: "Command providing the definition of a
+                                VsCode launch action \n Deprecated; removed in v1alpha2"
                               oneOf:
                               - required:
                                 - uri
@@ -2112,8 +2113,8 @@ spec:
                               - id
                               type: object
                             vscodeTask:
-                              description: Command providing the definition of a VsCode
-                                Task
+                              description: "Command providing the definition of a
+                                VsCode Task \n Deprecated; removed in v1alpha2"
                               oneOf:
                               - required:
                                 - uri
@@ -2885,8 +2886,9 @@ spec:
                                         - id
                                         type: object
                                       vscodeLaunch:
-                                        description: Command providing the definition
-                                          of a VsCode launch action
+                                        description: "Command providing the definition
+                                          of a VsCode launch action \n Deprecated;
+                                          removed in v1alpha2"
                                         oneOf:
                                         - required:
                                           - uri
@@ -2944,8 +2946,9 @@ spec:
                                         - id
                                         type: object
                                       vscodeTask:
-                                        description: Command providing the definition
-                                          of a VsCode Task
+                                        description: "Command providing the definition
+                                          of a VsCode Task \n Deprecated; removed
+                                          in v1alpha2"
                                         oneOf:
                                         - required:
                                           - uri

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -326,8 +326,8 @@ spec:
                           - id
                           type: object
                         vscodeLaunch:
-                          description: Command providing the definition of a VsCode
-                            launch action
+                          description: "Command providing the definition of a VsCode
+                            launch action \n Deprecated; removed in v1alpha2"
                           oneOf:
                           - required:
                             - uri
@@ -381,8 +381,8 @@ spec:
                           - id
                           type: object
                         vscodeTask:
-                          description: Command providing the definition of a VsCode
-                            Task
+                          description: "Command providing the definition of a VsCode
+                            Task \n Deprecated; removed in v1alpha2"
                           oneOf:
                           - required:
                             - uri
@@ -1133,8 +1133,9 @@ spec:
                                     - id
                                     type: object
                                   vscodeLaunch:
-                                    description: Command providing the definition
-                                      of a VsCode launch action
+                                    description: "Command providing the definition
+                                      of a VsCode launch action \n Deprecated; removed
+                                      in v1alpha2"
                                     oneOf:
                                     - required:
                                       - uri
@@ -1192,8 +1193,8 @@ spec:
                                     - id
                                     type: object
                                   vscodeTask:
-                                    description: Command providing the definition
-                                      of a VsCode Task
+                                    description: "Command providing the definition
+                                      of a VsCode Task \n Deprecated; removed in v1alpha2"
                                     oneOf:
                                     - required:
                                       - uri
@@ -2051,8 +2052,8 @@ spec:
                               - id
                               type: object
                             vscodeLaunch:
-                              description: Command providing the definition of a VsCode
-                                launch action
+                              description: "Command providing the definition of a
+                                VsCode launch action \n Deprecated; removed in v1alpha2"
                               oneOf:
                               - required:
                                 - uri
@@ -2108,8 +2109,8 @@ spec:
                               - id
                               type: object
                             vscodeTask:
-                              description: Command providing the definition of a VsCode
-                                Task
+                              description: "Command providing the definition of a
+                                VsCode Task \n Deprecated; removed in v1alpha2"
                               oneOf:
                               - required:
                                 - uri
@@ -2881,8 +2882,9 @@ spec:
                                         - id
                                         type: object
                                       vscodeLaunch:
-                                        description: Command providing the definition
-                                          of a VsCode launch action
+                                        description: "Command providing the definition
+                                          of a VsCode launch action \n Deprecated;
+                                          removed in v1alpha2"
                                         oneOf:
                                         - required:
                                           - uri
@@ -2940,8 +2942,9 @@ spec:
                                         - id
                                         type: object
                                       vscodeTask:
-                                        description: Command providing the definition
-                                          of a VsCode Task
+                                        description: "Command providing the definition
+                                          of a VsCode Task \n Deprecated; removed
+                                          in v1alpha2"
                                         oneOf:
                                         - required:
                                           - uri

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -300,8 +300,8 @@ spec:
                       - id
                       type: object
                     vscodeLaunch:
-                      description: Command providing the definition of a VsCode launch
-                        action
+                      description: "Command providing the definition of a VsCode launch
+                        action \n Deprecated; removed in v1alpha2"
                       oneOf:
                       - required:
                         - uri
@@ -354,7 +354,8 @@ spec:
                       - id
                       type: object
                     vscodeTask:
-                      description: Command providing the definition of a VsCode Task
+                      description: "Command providing the definition of a VsCode Task
+                        \n Deprecated; removed in v1alpha2"
                       oneOf:
                       - required:
                         - uri
@@ -1086,8 +1087,9 @@ spec:
                                 - id
                                 type: object
                               vscodeLaunch:
-                                description: Command providing the definition of a
-                                  VsCode launch action
+                                description: "Command providing the definition of
+                                  a VsCode launch action \n Deprecated; removed in
+                                  v1alpha2"
                                 oneOf:
                                 - required:
                                   - uri
@@ -1144,8 +1146,8 @@ spec:
                                 - id
                                 type: object
                               vscodeTask:
-                                description: Command providing the definition of a
-                                  VsCode Task
+                                description: "Command providing the definition of
+                                  a VsCode Task \n Deprecated; removed in v1alpha2"
                                 oneOf:
                                 - required:
                                   - uri
@@ -1971,8 +1973,8 @@ spec:
                           - id
                           type: object
                         vscodeLaunch:
-                          description: Command providing the definition of a VsCode
-                            launch action
+                          description: "Command providing the definition of a VsCode
+                            launch action \n Deprecated; removed in v1alpha2"
                           oneOf:
                           - required:
                             - uri
@@ -2026,8 +2028,8 @@ spec:
                           - id
                           type: object
                         vscodeTask:
-                          description: Command providing the definition of a VsCode
-                            Task
+                          description: "Command providing the definition of a VsCode
+                            Task \n Deprecated; removed in v1alpha2"
                           oneOf:
                           - required:
                             - uri
@@ -2778,8 +2780,9 @@ spec:
                                     - id
                                     type: object
                                   vscodeLaunch:
-                                    description: Command providing the definition
-                                      of a VsCode launch action
+                                    description: "Command providing the definition
+                                      of a VsCode launch action \n Deprecated; removed
+                                      in v1alpha2"
                                     oneOf:
                                     - required:
                                       - uri
@@ -2837,8 +2840,8 @@ spec:
                                     - id
                                     type: object
                                   vscodeTask:
-                                    description: Command providing the definition
-                                      of a VsCode Task
+                                    description: "Command providing the definition
+                                      of a VsCode Task \n Deprecated; removed in v1alpha2"
                                     oneOf:
                                     - required:
                                       - uri

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -298,8 +298,8 @@ spec:
                       - id
                       type: object
                     vscodeLaunch:
-                      description: Command providing the definition of a VsCode launch
-                        action
+                      description: "Command providing the definition of a VsCode launch
+                        action \n Deprecated; removed in v1alpha2"
                       oneOf:
                       - required:
                         - uri
@@ -352,7 +352,8 @@ spec:
                       - id
                       type: object
                     vscodeTask:
-                      description: Command providing the definition of a VsCode Task
+                      description: "Command providing the definition of a VsCode Task
+                        \n Deprecated; removed in v1alpha2"
                       oneOf:
                       - required:
                         - uri
@@ -1084,8 +1085,9 @@ spec:
                                 - id
                                 type: object
                               vscodeLaunch:
-                                description: Command providing the definition of a
-                                  VsCode launch action
+                                description: "Command providing the definition of
+                                  a VsCode launch action \n Deprecated; removed in
+                                  v1alpha2"
                                 oneOf:
                                 - required:
                                   - uri
@@ -1142,8 +1144,8 @@ spec:
                                 - id
                                 type: object
                               vscodeTask:
-                                description: Command providing the definition of a
-                                  VsCode Task
+                                description: "Command providing the definition of
+                                  a VsCode Task \n Deprecated; removed in v1alpha2"
                                 oneOf:
                                 - required:
                                   - uri
@@ -1969,8 +1971,8 @@ spec:
                           - id
                           type: object
                         vscodeLaunch:
-                          description: Command providing the definition of a VsCode
-                            launch action
+                          description: "Command providing the definition of a VsCode
+                            launch action \n Deprecated; removed in v1alpha2"
                           oneOf:
                           - required:
                             - uri
@@ -2024,8 +2026,8 @@ spec:
                           - id
                           type: object
                         vscodeTask:
-                          description: Command providing the definition of a VsCode
-                            Task
+                          description: "Command providing the definition of a VsCode
+                            Task \n Deprecated; removed in v1alpha2"
                           oneOf:
                           - required:
                             - uri
@@ -2776,8 +2778,9 @@ spec:
                                     - id
                                     type: object
                                   vscodeLaunch:
-                                    description: Command providing the definition
-                                      of a VsCode launch action
+                                    description: "Command providing the definition
+                                      of a VsCode launch action \n Deprecated; removed
+                                      in v1alpha2"
                                     oneOf:
                                     - required:
                                       - uri
@@ -2835,8 +2838,8 @@ spec:
                                     - id
                                     type: object
                                   vscodeTask:
-                                    description: Command providing the definition
-                                      of a VsCode Task
+                                    description: "Command providing the definition
+                                      of a VsCode Task \n Deprecated; removed in v1alpha2"
                                     oneOf:
                                     - required:
                                       - uri

--- a/pkg/apis/workspaces/v1alpha1/attributes_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/attributes_conversion.go
@@ -31,10 +31,6 @@ func getCommandAttributes(command *Command) map[string]string {
 		return command.Exec.Attributes
 	case command.Apply != nil:
 		return command.Apply.Attributes
-	case command.VscodeTask != nil:
-		return command.VscodeTask.Attributes
-	case command.VscodeLaunch != nil:
-		return command.VscodeLaunch.Attributes
 	case command.Composite != nil:
 		return command.Composite.Attributes
 	case command.Custom != nil:

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -86,10 +86,14 @@ type Command struct {
 	Apply *ApplyCommand `json:"apply,omitempty"`
 
 	// Command providing the definition of a VsCode Task
+	//
+	// Deprecated; removed in v1alpha2
 	// +optional
 	VscodeTask *VscodeConfigurationCommand `json:"vscodeTask,omitempty"`
 
 	// Command providing the definition of a VsCode launch action
+	//
+	// Deprecated; removed in v1alpha2
 	// +optional
 	VscodeLaunch *VscodeConfigurationCommand `json:"vscodeLaunch,omitempty"`
 

--- a/pkg/apis/workspaces/v1alpha1/commands_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/commands_conversion.go
@@ -27,10 +27,6 @@ func convertCommandTo_v1alpha2(src *Command, dest *v1alpha2.Command) error {
 		srcAttributes = src.Exec.Attributes
 	case src.Apply != nil:
 		srcAttributes = src.Apply.Attributes
-	case src.VscodeTask != nil:
-		srcAttributes = src.VscodeTask.Attributes
-	case src.VscodeLaunch != nil:
-		srcAttributes = src.VscodeLaunch.Attributes
 	case src.Composite != nil:
 		srcAttributes = src.Composite.Attributes
 	case src.Custom != nil:
@@ -76,12 +72,6 @@ func convertCommandFrom_v1alpha2(src *v1alpha2.Command, dest *Command) error {
 	case dest.Exec != nil:
 		dest.Exec.Attributes = destAttributes
 		dest.Exec.Id = id
-	case dest.VscodeLaunch != nil:
-		dest.VscodeLaunch.Attributes = destAttributes
-		dest.VscodeLaunch.Id = id
-	case dest.VscodeTask != nil:
-		dest.VscodeTask.Attributes = destAttributes
-		dest.VscodeTask.Id = id
 	}
 	return err
 }

--- a/pkg/apis/workspaces/v1alpha1/conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/conversion_test.go
@@ -40,7 +40,7 @@ var componentFuzzFunc = func(component *Component, c fuzz.Continue) {
 }
 
 var commandFuzzFunc = func(command *Command, c fuzz.Continue) {
-	switch c.Intn(6) {
+	switch c.Intn(4) {
 	case 0:
 		c.Fuzz(&command.Apply)
 	case 1:
@@ -49,10 +49,6 @@ var commandFuzzFunc = func(command *Command, c fuzz.Continue) {
 		c.Fuzz(&command.Custom)
 	case 3:
 		c.Fuzz(&command.Exec)
-	case 4:
-		c.Fuzz(&command.VscodeLaunch)
-	case 5:
-		c.Fuzz(&command.VscodeTask)
 	}
 }
 
@@ -130,7 +126,7 @@ var parentComponentFuzzFunc = func(component *Component, c fuzz.Continue) {
 var parentCommandFuzzFunc = func(command *Command, c fuzz.Continue) {
 	// Do not generate Custom commands for Parents
 	// Also: commands in Parents cannot have attributes.
-	switch c.Intn(5) {
+	switch c.Intn(3) {
 	case 0:
 		c.Fuzz(&command.Apply)
 		if command.Apply != nil {
@@ -145,16 +141,6 @@ var parentCommandFuzzFunc = func(command *Command, c fuzz.Continue) {
 		c.Fuzz(&command.Exec)
 		if command.Exec != nil {
 			command.Exec.Attributes = nil
-		}
-	case 3:
-		c.Fuzz(&command.VscodeLaunch)
-		if command.VscodeLaunch != nil {
-			command.VscodeLaunch.Attributes = nil
-		}
-	case 4:
-		c.Fuzz(&command.VscodeTask)
-		if command.VscodeTask != nil {
-			command.VscodeTask.Attributes = nil
 		}
 	}
 }

--- a/pkg/apis/workspaces/v1alpha1/plugin_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/plugin_conversion.go
@@ -138,10 +138,6 @@ func convertPluginComponentCommandFrom_v1alpha2(src *v1alpha2.CommandPluginOverr
 		dest.Composite.Id = srcId
 	case src.Exec != nil:
 		dest.Exec.Id = srcId
-	case src.VscodeLaunch != nil:
-		dest.VscodeLaunch.Id = srcId
-	case src.VscodeTask != nil:
-		dest.VscodeTask.Id = srcId
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
Fixes conversion tests to not cover VSCodeTask and VSCodeLaunch, so as to avoid the incompatibility between `v1alpha1` and `v1alpha2`. 

Note that though the vscode-related commands are still in v1alpha1, they are effectively removed there too, since they are dropped in the conversion, and v1alpha2 is the hub version.
